### PR TITLE
Force usage of snakemake 5.1.5

### DIFF
--- a/envs/auto-asm.yaml
+++ b/envs/auto-asm.yaml
@@ -2,6 +2,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake>=5.1
+  - snakemake=5.1.5
   - networkx>=2.1
   - pygraphviz>=1.3


### PR DESCRIPTION
Due to a bug in snakemake 5.2.0 the usage of snakemake 5.1.5 is required for now