### PR TITLE
Force the usage of conda-forge

### DIFF
--- a/envs/merge_short_read_alignments_polish.yaml
+++ b/envs/merge_short_read_alignments_polish.yaml
@@ -1,4 +1,5 @@
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - samtools=1.8


### PR DESCRIPTION
Without conda-forge ncurses is installed from defaults which makes samtools non-functional.